### PR TITLE
Switch to maintained fork for `maybe-async-cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ defmt = { version = "0.3", optional = true }
 embedded-hal = { version = "1.0", optional = true }
 embedded-hal-async = { version = "1.0", optional = true }
 log = { version = "0.4", optional = true }
-maybe-async-cfg = { git = "https://github.com/korbin/maybe-async-cfg" }
+maybe-async-cfg2 = { version = "0.3" }
 
 [features]
 async = ["dep:embedded-hal-async"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl MaskEnable {
     }
 }
 
-#[maybe_async_cfg::maybe(
+#[maybe_async_cfg2::maybe(
     sync(feature = "sync", self = "INA260"),
     async(feature = "async", keep_self)
 )]
@@ -290,7 +290,7 @@ pub struct AsyncINA260<I2C> {
     state: u16,
 }
 
-#[maybe_async_cfg::maybe(
+#[maybe_async_cfg2::maybe(
     sync(
         feature = "sync",
         self = "INA260",


### PR DESCRIPTION
I forked `maybe-async-cfg` (which itself is a fork of `maybe-async`), cleaned up the docs a bit, and published it at `maybe-async-cfg2`

https://crates.io/crates/maybe-async-cfg2